### PR TITLE
Change msspiIssuerList to be QSslSocket property instead of global one

### DIFF
--- a/src/network/ssl/qsslconfiguration.cpp
+++ b/src/network/ssl/qsslconfiguration.cpp
@@ -58,7 +58,6 @@ const char QSslConfiguration::NextProtocolSpdy3_0[] = "spdy/3";
 const char QSslConfiguration::NextProtocolHttp1_1[] = "http/1.1";
 
 QByteArray QSslConfiguration::msspiCertStore;
-QList<QByteArray> QSslConfiguration::msspiIssuerList;
 
 /*!
     \class QSslConfiguration

--- a/src/network/ssl/qsslconfiguration.h
+++ b/src/network/ssl/qsslconfiguration.h
@@ -198,7 +198,6 @@ public:
     static const char NextProtocolHttp1_1[];
 
     static QByteArray msspiCertStore;
-    static QList<QByteArray> msspiIssuerList;
 
 private:
     friend class QSslSocket;

--- a/src/network/ssl/qsslsocket_openssl.cpp
+++ b/src/network/ssl/qsslsocket_openssl.cpp
@@ -1001,21 +1001,21 @@ static int QSslSocketMSSPIWrite( QSslSocketBackendPrivate * qssl, const void * b
 
 static int QSslSocketCertCallback( QSslSocketBackendPrivate * qssl )
 {
-    if( QSslConfiguration::msspiIssuerList.isEmpty() )
-    {
-        const char * bufs[64];
-        int lens[64];
-        size_t count = 64;
+    QSslSocket *socketObject =  static_cast<QSslSocket *>(qssl->q_ptr);
+    QList<QByteArray> msspiIssuerList;
+    const char * bufs[64];
+    int lens[64];
+    size_t count = 64;
 
-        if( msspi_get_issuerlist( qssl->msh, bufs, lens, &count ) )
+    if( msspi_get_issuerlist( qssl->msh, bufs, lens, &count ) )
+    {
+        for( size_t i = 0; i < count; i++ )
         {
-            for( size_t i = 0; i < count; i++ )
-            {
-                QByteArray issuer( bufs[i], lens[i] );
-                QSslConfiguration::msspiIssuerList.push_back( issuer );
-            }
+            QByteArray issuer( bufs[i], lens[i] );
+            msspiIssuerList.push_back( issuer );
         }
     }
+    socketObject->setProperty("msspiIssuerList", QVariant::fromValue<QList<QByteArray>>(msspiIssuerList));
 
     return 1;
 }


### PR DESCRIPTION
This change allowing ssl sockets to be used in multithreaded environment